### PR TITLE
READMEへのDB設計記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,25 @@ Things you may want to cover:
 
 ### Association
 - has_many :contents
+- has_many :groups_users
 - has_many :groups, through: :groups_users
 
 ## groupsテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :contents
+- has_many :groups_users
 - has_many :users, through: :groups_users
 
-## contentsテーブル
+## messagesテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
+|text|text||
 |image|string||
 |user_id|references|foreign_key: true|
 |group_id|references|foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Things you may want to cover:
 |password|string|null: false|
 
 ### Association
-- has_many :contents
+- has_many :messages
 - has_many :groups_users
 - has_many :groups, through: :groups_users
 
@@ -55,7 +55,7 @@ Things you may want to cover:
 |name|string|null: false|
 
 ### Association
-- has_many :contents
+- has_many :messages
 - has_many :groups_users
 - has_many :users, through: :groups_users
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Things you may want to cover:
 
 * ...
 
-```
+
 ## groups_usersテーブル
 
 |Column|Type|Options|
@@ -69,4 +69,3 @@ Things you may want to cover:
 ### Association
 - belong_to :user
 - belong_to :group
-```

--- a/README.md
+++ b/README.md
@@ -22,3 +22,51 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+```
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, unique: true|
+|email|string|null: false ,unique: true|
+|password|string|null: false|
+
+### Association
+- has_many :contents
+- has_many :groups, through: :groups_users
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+
+### Association
+- has_many :contents
+- has_many :users, through: :groups_users
+
+## contentsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|image|string||
+|user_id|references|foreign_key: true|
+|group_id|references|foreign_key: true|
+
+### Association
+- belong_to :user
+- belong_to :group
+```


### PR DESCRIPTION
#what
README.mdにDBの設計を記載。
usesテーブル、groupsテーブル、contentsテーブル、中間テーブルとしてusers_groupsテーブルを作成。

#why
ユーザー登録機能、グループ作成機能、投稿機能実装にあたり、データを登録・保存する場所が必要なため。